### PR TITLE
Implement basic reading and playing of MIDI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,11 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "byteorder"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,10 +75,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding-index-japanese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-korean 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-simpchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-singlebyte 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "hello_midi"
 version = "0.1.0"
 dependencies = [
  "midir 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rimd 0.0.2 (git+https://github.com/RustAudio/rimd.git)",
 ]
 
 [[package]]
@@ -113,14 +176,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "proc-macro2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rimd"
+version = "0.0.2"
+source = "git+https://github.com/RustAudio/rimd.git#6e623dbce990605df95635648710d3f0675a615c"
+dependencies = [
+ "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "time"
@@ -131,6 +247,11 @@ dependencies = [
  "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "void"
@@ -180,18 +301,33 @@ dependencies = [
 "checksum alsa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b0edcbbf9ef68f15ae1b620f722180b82a98b6f0628d30baa6b8d2a5abc87d58"
 "checksum bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "32866f4d103c4e438b1db1158aa1b1a80ee078e5d77a59a2f906fd62a577389c"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
+"checksum byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "74c0b906e9446b0a2e4f760cdb3fa4b2c48cdc6db8766a845c54b6ff063fd2e9"
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum coremidi 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33326bbe31e4f0102c694281998365bf37ecd7ed08d2993ded0c19c57579cbed"
 "checksum coremidi-sys 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "07f05827cebb30dcd539ff1ac9bf6764f574a15fa147f8572f99d7617142f95e"
+"checksum encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+"checksum encoding-index-japanese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+"checksum encoding-index-korean 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+"checksum encoding-index-simpchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+"checksum encoding-index-singlebyte 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+"checksum encoding-index-tradchinese 1.20141219.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+"checksum encoding_index_tests 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 "checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
 "checksum memalloc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df39d232f5c40b0891c10216992c2f250c054105cb1e56f0fc9032db6203ecc1"
 "checksum midir 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e653b919aca8b5f2697854f1819b33bfe49bcb3378abb0dbd834ce43ede9c7b1"
 "checksum nix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2c5afeb0198ec7be8569d666644b574345aad2e95a53baf3a532da3e0f3fb32"
+"checksum num-derive 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d2c31b75c36a993d30c7a13d70513cb93f02acafdd5b7ba250f9b0e18615de7"
+"checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"
 "checksum pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f"
+"checksum proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "effdb53b25cdad54f8f48843d67398f7ef2e14f12c1b4cb4effc549a6462a4d6"
+"checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
+"checksum rimd 0.0.2 (git+https://github.com/RustAudio/rimd.git)" = "<none>"
+"checksum syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c67da57e61ebc7b7b6fff56bb34440ca3a83db037320b0507af4c10368deda7d"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,0 +1,201 @@
+[[package]]
+name = "alsa"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "alsa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitflags"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "core-foundation"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "coremidi"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "coremidi-sys 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "coremidi-sys"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hello_midi"
+version = "0.1.0"
+dependencies = [
+ "midir 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memalloc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "midir"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "alsa 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "coremidi 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memalloc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winmm-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "time"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winmm-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[metadata]
+"checksum alsa 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fe0820f7fc33380123dcd5deaadbc4467d56b6cecb60e5d80d6cd523a9664adc"
+"checksum alsa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b0edcbbf9ef68f15ae1b620f722180b82a98b6f0628d30baa6b8d2a5abc87d58"
+"checksum bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "32866f4d103c4e438b1db1158aa1b1a80ee078e5d77a59a2f906fd62a577389c"
+"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
+"checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
+"checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
+"checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
+"checksum coremidi 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33326bbe31e4f0102c694281998365bf37ecd7ed08d2993ded0c19c57579cbed"
+"checksum coremidi-sys 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "07f05827cebb30dcd539ff1ac9bf6764f574a15fa147f8572f99d7617142f95e"
+"checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
+"checksum memalloc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df39d232f5c40b0891c10216992c2f250c054105cb1e56f0fc9032db6203ecc1"
+"checksum midir 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e653b919aca8b5f2697854f1819b33bfe49bcb3378abb0dbd834ce43ede9c7b1"
+"checksum nix 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2c5afeb0198ec7be8569d666644b574345aad2e95a53baf3a532da3e0f3fb32"
+"checksum pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f"
+"checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
+"checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum winmm-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "20a57a816b63ca4bf31aec70b4c334be13c4b73a30ab5b546135041627866035"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "hello_midi"
 version = "0.1.0"
-authors = ["Terkwood <metaterkhorn@gmail.com>"]
+authors = ["Terkwood <<>>"]
 
 [dependencies]
 midir = "0.5.0"
+
+[dependencies.rimd]
+git = "https://github.com/RustAudio/rimd.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 authors = ["Terkwood <metaterkhorn@gmail.com>"]
 
 [dependencies]
+midir = "0.5.0"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ cargo run ~/Documents/Goldberg_Variations.mid
 
 ## MIDI sample data
 
-We ran [rimd](https://github.com/RustAudio/rimd) test bin against the Goldberg Variations and found a lot of Note On events.
+We ran [rimd](https://github.com/RustAudio/rimd) test bin against the Goldberg Variations and found the expected header data, as well as plenty of Note On events.
 
 ```sh
 % cargo run --bin test # rimd
@@ -31,35 +31,54 @@ events:
   time: 0	Meta Event: Time Signature: 3/4, 24 ticks/metronome click, 8 32nd notes/quarter note
   time: 0	Meta Event: Key Signature, 1 sharps/flats, Major
   time: 0	Meta Event: Set Tempo, microseconds/quarter note: 833333
-  time: 0	Control Change: [121,0]	channel: Some(0)
-  time: 0	Program Change: [1]	channel: Some(0)
-  time: 0	Control Change: [7,127]	channel: Some(0)
-  time: 0	Control Change: [10,64]	channel: Some(0)
-  time: 0	Control Change: [91,0]	channel: Some(0)
-  time: 0	Control Change: [93,0]	channel: Some(0)
-  time: 0	Meta Event: MIDI Port Prefix Assignment, port: 0
+  ...
   time: 0	Note On: [79,80]	channel: Some(0)
   time: 479	Note On: [79,0]	channel: Some(0)
   time: 480	Note On: [79,80]	channel: Some(0)
   time: 959	Note On: [79,0]	channel: Some(0)
-```
-
-...
-
-```sh
+  ...
   time: 3715	Note On: [67,0]	channel: Some(0)
   time: 3720	Note On: [69,80]	channel: Some(0)
   time: 3778	Note On: [67,80]	channel: Some(0)
   time: 3784	Note On: [69,0]	channel: Some(0)
-  time: 3839	Note On: [67,0]	channel: Some(0)
-  time: 3839	Note On: [69,80]	channel: Some(0)
-  time: 3899	Note On: [67,80]	channel: Some(0)
-  time: 3900	Note On: [69,0]	channel: Some(0)
-  time: 3957	Note On: [67,0]	channel: Some(0)
-  time: 3957	Note On: [69,80]	channel: Some(0)
 ```
 
 We can see by reading http://www.onicos.com/staff/iz/formats/midi-event.html that most of these are "Channel 1 Note On".
+
+## Notes on Midi Time Management
+
+MIDI Note On / Note Off events are ordered in time.  Each event contains a `delta_time` (vtime) field representing the time elapsed since the last event.
+
+From `rimd` documentation in `meta.rs`:
+
+```rust
+    /// The parameter `clocks_per_tick` is the number of MIDI Clocks per metronome tick.
+
+    /// Normally, there are 24 MIDI Clocks per quarter note.
+    /// However, some software allows this to be set by the user.
+    /// The parameter `num_32nd_notes_per_24_clocks` defines this in terms of the
+    /// number of 1/32 notes which make up the usual 24 MIDI Clocks
+    /// (the 'standard' quarter note).  8 is standard
+    pub fn time_signature(numerator: u8, denominator: u8, clocks_per_tick: u8, num_32nd_notes_per_24_clocks: u8) -> MetaEvent {
+        MetaEvent {
+            command: MetaCommand::TimeSignature,
+            length: 4,
+            data: vec![numerator,denominator,clocks_per_tick,num_32nd_notes_per_24_clocks],
+        }
+    }
+```
+
+Open Goldberg Variations JS Bach midi appears to support the standard timing when loaded:
+
+```text
+vtime 0 event time: 0	Meta Event: Time Signature: 3/4, 24 ticks/metronome click, 8 32nd notes/quarter note
+  ...snip...
+  vtime 0 event time: 0	Meta Event: Set Tempo, microseconds/quarter note: 833333
+```
+
+A more detailed specification of the byte-level MIDI delta time (vtime) field can be found here:
+
+https://www.csie.ntu.edu.tw/~r92092/ref/midi/
 
 ## Using SoundFlower to record MIDI
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ events:
 
 We can see by reading http://www.onicos.com/staff/iz/formats/midi-event.html that most of these are "Channel 1 Note On".
 
+## Using SoundFlower to record MIDI
+
+Not strictly related to the build, but...
+
+This is helpful for redirecting your successful
+playback of MIDI to a sound file that you're recording.
+
+https://github.com/mattingalls/Soundflower/releases/tag/2.0b2
+
 ## Acknowledgements
 
 Bach's Goldberg Variations are [available under Creative Commons License here](https://www.opengoldbergvariations.org/).

--- a/README.md
+++ b/README.md
@@ -2,10 +2,67 @@
 
 Starter project for MIDI with rust.
 
+## Usage
+
+We recommend downloading the JS Bach Goldberg Variations from https://www.opengoldbergvariations.org/.
+
+```sh
+cargo run ~/Documents/Goldberg_Variations.mid
+```
+
 ## Mac Config
 
 * Install SimpleSynth according to https://github.com/wbsoft/frescobaldi/wiki/MIDI-playback-on-Mac-OS-X
 
+## MIDI sample data
+
+We ran [rimd](https://github.com/RustAudio/rimd) test bin against the Goldberg Variations and found a lot of Note On events.
+
+```sh
+% cargo run --bin test # rimd
+
+Reading: /Documents/Goldberg_Variations.mid
+format: multiple track
+tracks: 2
+division: 480
+
+1: Track, copyright: [none], name: [none]
+events:
+  time: 0	Meta Event: Time Signature: 3/4, 24 ticks/metronome click, 8 32nd notes/quarter note
+  time: 0	Meta Event: Key Signature, 1 sharps/flats, Major
+  time: 0	Meta Event: Set Tempo, microseconds/quarter note: 833333
+  time: 0	Control Change: [121,0]	channel: Some(0)
+  time: 0	Program Change: [1]	channel: Some(0)
+  time: 0	Control Change: [7,127]	channel: Some(0)
+  time: 0	Control Change: [10,64]	channel: Some(0)
+  time: 0	Control Change: [91,0]	channel: Some(0)
+  time: 0	Control Change: [93,0]	channel: Some(0)
+  time: 0	Meta Event: MIDI Port Prefix Assignment, port: 0
+  time: 0	Note On: [79,80]	channel: Some(0)
+  time: 479	Note On: [79,0]	channel: Some(0)
+  time: 480	Note On: [79,80]	channel: Some(0)
+  time: 959	Note On: [79,0]	channel: Some(0)
+```
+
+...
+
+```sh
+  time: 3715	Note On: [67,0]	channel: Some(0)
+  time: 3720	Note On: [69,80]	channel: Some(0)
+  time: 3778	Note On: [67,80]	channel: Some(0)
+  time: 3784	Note On: [69,0]	channel: Some(0)
+  time: 3839	Note On: [67,0]	channel: Some(0)
+  time: 3839	Note On: [69,80]	channel: Some(0)
+  time: 3899	Note On: [67,80]	channel: Some(0)
+  time: 3900	Note On: [69,0]	channel: Some(0)
+  time: 3957	Note On: [67,0]	channel: Some(0)
+  time: 3957	Note On: [69,80]	channel: Some(0)
+```
+
+We can see by reading http://www.onicos.com/staff/iz/formats/midi-event.html that most of these are "Channel 1 Note On".
+
 ## Acknowledgements
+
+Bach's Goldberg Variations are [available under Creative Commons License here](https://www.opengoldbergvariations.org/).
 
 Big thanks to [midir library](https://github.com/Boddlnagg/midir).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hello_midi
 
-Starter project for MIDI with rust.
+Uses [rimd](https://github.com/RustAudio/rimd) and [midir](https://github.com/Boddlnagg/midir) libs to read MIDI and play it. Tested on Mac OS X using [SimpleSynth](http://notahat.com/simplesynth/) and the public domain JS Bach Goldberg variations.
 
 ## Usage
 
@@ -48,6 +48,8 @@ We can see by reading http://www.onicos.com/staff/iz/formats/midi-event.html tha
 ## Notes on Midi Time Management
 
 MIDI Note On / Note Off events are ordered in time.  Each event contains a `delta_time` (vtime) field representing the time elapsed since the last event.
+
+In most cases, you can use the headers/metadata at the beginning of the file to establish a simple relationship between microseconds and "ticks" of the MIDI score.
 
 From `rimd` documentation in `meta.rs`:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hello_midi
 
-Uses [rimd](https://github.com/RustAudio/rimd) and [midir](https://github.com/Boddlnagg/midir) libs to read MIDI and play it. Tested on Mac OS X using [SimpleSynth](http://notahat.com/simplesynth/) and the public domain JS Bach Goldberg variations.
+Uses [rtmidi](https://github.com/thestk/rtmidi), [rimd](https://github.com/RustAudio/rimd) and [midir](https://github.com/Boddlnagg/midir) libs to read MIDI and play it. Tested on Mac OS X using [SimpleSynth](http://notahat.com/simplesynth/) and the public domain JS Bach Goldberg variations.
 
 ## Usage
 
@@ -96,3 +96,7 @@ https://github.com/mattingalls/Soundflower/releases/tag/2.0b2
 Bach's Goldberg Variations are [available under Creative Commons License here](https://www.opengoldbergvariations.org/).
 
 Big thanks to [midir library](https://github.com/Boddlnagg/midir).
+
+Big thanks to [rimd library](https://github.com/RustAudio/rimd).
+
+Big thanks to [rtmidi library](https://github.com/thestk/rtmidi).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# hello_midi
+
+Starter project for MIDI with rust.
+
+## Mac Config
+
+* Install SimpleSynth according to https://github.com/wbsoft/frescobaldi/wiki/MIDI-playback-on-Mac-OS-X
+
+## Acknowledgements
+
+Big thanks to [midir library](https://github.com/Boddlnagg/midir).

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -1,0 +1,6 @@
+// from http://www.onicos.com/staff/iz/formats/midi-event.html
+
+pub const CHANNEL_OFF_FIRST: u8 = 0x80;
+pub const CHANNEL_OFF_LAST: u8 = 0x8F;
+pub const CHANNEL_ON_FIRST: u8 = 0x90;
+pub const CHANNEL_ON_LAST: u8 = 0x9F;

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,14 +52,9 @@ fn run() -> Result<(), Box<Error>> {
             let _ = conn_out.send(&[NOTE_OFF_MSG, note, VELOCITY]);
         };
         
-        play_note(66, 4);
-        play_note(65, 3);
-        play_note(63, 1);
-        play_note(61, 6);
-        play_note(59, 2);
-        play_note(58, 4);
-        play_note(56, 4);
-        play_note(54, 4);
+        for i in 0..66 {
+            play_note(i, 2);
+        }
     }
     sleep(Duration::from_millis(150));
     println!("\nClosing connection");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,70 @@
+extern crate midir;
+
+use std::thread::sleep;
+use std::time::Duration;
+use std::io::{stdin, stdout, Write};
+use std::error::Error;
+
+use midir::MidiOutput;
+
 fn main() {
-    println!("Hello, world!");
+    match run() {
+        Ok(_) => (),
+        Err(err) => println!("Error: {}", err.description())
+    }
+}
+
+fn run() -> Result<(), Box<Error>> {
+    let midi_out = MidiOutput::new("My Test Output")?;
+    
+    // Get an output port (read from console if multiple are available)
+    let out_port = match midi_out.port_count() {
+        0 => return Err("no output port found".into()),
+        1 => {
+            println!("Choosing the only available output port: {}", midi_out.port_name(0).unwrap());
+            0
+        },
+        _ => {
+            println!("\nAvailable output ports:");
+            for i in 0..midi_out.port_count() {
+                println!("{}: {}", i, midi_out.port_name(i).unwrap());
+            }
+            print!("Please select output port: ");
+            stdout().flush()?;
+            let mut input = String::new();
+            stdin().read_line(&mut input)?;
+            input.trim().parse()?
+        }
+    };
+    
+    println!("\nOpening connection");
+    let mut conn_out = midi_out.connect(out_port, "midir-test")?;
+    println!("Connection open. Listen!");
+    {
+        // Define a new scope in which the closure `play_note` borrows conn_out, so it can be called easily
+        let mut play_note = |note: u8, duration: u64| {
+            const NOTE_ON_MSG: u8 = 0x90;
+            const NOTE_OFF_MSG: u8 = 0x80;
+            const VELOCITY: u8 = 0x64;
+            // We're ignoring errors in here
+            let _ = conn_out.send(&[NOTE_ON_MSG, note, VELOCITY]);
+            sleep(Duration::from_millis(duration * 150));
+            let _ = conn_out.send(&[NOTE_OFF_MSG, note, VELOCITY]);
+        };
+        
+        play_note(66, 4);
+        play_note(65, 3);
+        play_note(63, 1);
+        play_note(61, 6);
+        play_note(59, 2);
+        play_note(58, 4);
+        play_note(56, 4);
+        play_note(54, 4);
+    }
+    sleep(Duration::from_millis(150));
+    println!("\nClosing connection");
+    // This is optional, the connection would automatically be closed as soon as it goes out of scope
+    conn_out.close();
+    println!("Connection closed");
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,29 +1,173 @@
 extern crate midir;
-
-use std::thread::sleep;
-use std::time::Duration;
-use std::io::{stdin, stdout, Write};
-use std::error::Error;
+extern crate rimd;
 
 use midir::MidiOutput;
+use rimd::{Event, SMFError, TrackEvent, SMF};
+use std::env::{args, Args};
+use std::error::Error;
+use std::io::{stdin, stdout, Write};
+use std::path::Path;
+use std::thread::sleep;
+use std::time::Duration;
 
-fn main() {
-    match run() {
-        Ok(_) => (),
-        Err(err) => println!("Error: {}", err.description())
+mod channels;
+
+const DEFAULT_VEC_CAPACITY: usize = 133000;
+
+#[derive(Debug)]
+pub enum ChannelNote {
+    On(u8),
+    Off(u8),
+}
+
+impl ChannelNote {
+    pub fn new(channel: u8) -> Option<ChannelNote> {
+        if channel >= channels::CHANNEL_OFF_FIRST && channel <= channels::CHANNEL_OFF_LAST {
+            Some(ChannelNote::Off(channel))
+        } else if channel >= channels::CHANNEL_ON_FIRST && channel <= channels::CHANNEL_ON_LAST {
+            Some(ChannelNote::On(channel))
+        } else {
+            None
+        }
     }
 }
 
-fn run() -> Result<(), Box<Error>> {
-    let midi_out = MidiOutput::new("My Test Output")?;
-    
+#[derive(Debug)]
+pub struct MidiNote {
+    channel_note: ChannelNote,
+    time: u64,
+    vtime: u64,
+    note: u8,
+    velocity: u8,
+}
+
+fn main() {
+    let mut args: Args = args();
+    args.next();
+    let pathstr = &match args.next() {
+        Some(s) => s,
+        None => panic!("Please pass a path to an SMF to test"),
+    }[..];
+
+    let track_events = load_midi_file(pathstr);
+    println!("We have {} track events", track_events.len());
+
+    let timed_midi_messages = midi_messages_from(track_events);
+    println!("We have {} timed midi messages", timed_midi_messages.len());
+
+    for i in 0..20 {
+        println!("\t{:?}", timed_midi_messages[i])
+    }
+
+    let notes = notes_in_channel(timed_midi_messages);
+
+    println!("We have {} PlayNote instructions", notes.len());
+    for n in notes.iter() {
+        println!("\tvtime hex {:04X} ... {:?}", n.vtime, n);
+    }
+
+    match run(notes) {
+        Ok(_) => (),
+        Err(err) => println!("Error: {}", err.description()),
+    }
+}
+
+fn load_midi_file(pathstr: &str) -> Vec<TrackEvent> {
+    let mut events: Vec<TrackEvent> = Vec::with_capacity(DEFAULT_VEC_CAPACITY);
+    let mut count: u16 = 0;
+    match SMF::from_file(&Path::new(&pathstr[..])) {
+        Ok(smf) => {
+            for track in smf.tracks.iter() {
+                let mut time: u64 = 0;
+                for event in track.events.iter() {
+                    if count < 200 {
+                        // TODO remove
+                        count += 1;
+                        println!(
+                            "  vtime {} event {}",
+                            event.vtime,
+                            event.fmt_with_time_offset(time)
+                        );
+                    }
+                    events.push(event.clone());
+                    time += event.vtime;
+                }
+            }
+        }
+        Err(e) => match e {
+            SMFError::InvalidSMFFile(s) => {
+                println!("{}", s);
+            }
+            SMFError::Error(e) => {
+                println!("io: {}", e);
+            }
+            SMFError::MidiError(e) => {
+                println!("Midi Error: {}", e);
+            }
+            SMFError::MetaError(_) => {
+                println!("Meta Error");
+            }
+        },
+    };
+    events
+}
+
+#[derive(Debug)]
+pub struct TimedMidiMessage {
+    pub vtime: u64,
+    pub data: Vec<u8>,
+}
+
+fn midi_messages_from(track_events: Vec<TrackEvent>) -> Vec<TimedMidiMessage> {
+    let mut midi_messages: Vec<TimedMidiMessage> = Vec::with_capacity(DEFAULT_VEC_CAPACITY);
+
+    for te in track_events {
+        match te {
+            TrackEvent { vtime, event } => match event {
+                Event::Midi(m) => midi_messages.push(TimedMidiMessage {
+                    vtime,
+                    data: m.data,
+                }),
+                Event::Meta(_m) => {}
+            },
+        }
+    }
+
+    midi_messages
+}
+
+fn notes_in_channel(midi_messages: Vec<TimedMidiMessage>) -> Vec<MidiNote> {
+    let mut time: u64 = 0;
+    let mut notes: Vec<MidiNote> = Vec::with_capacity(DEFAULT_VEC_CAPACITY);
+    for msg in midi_messages {
+        time += msg.vtime;
+        if let Some(cn) = ChannelNote::new(msg.data[0]) {
+            notes.push(MidiNote {
+                channel_note: cn,
+                time: time,
+                vtime: msg.vtime,
+                note: msg.data[1],
+                velocity: msg.data[2],
+            })
+        }
+    }
+
+    notes
+}
+
+fn run(notes: Vec<MidiNote>) -> Result<(), Box<Error>> {
+    let midi_out = MidiOutput::new("Hello MIDI Bach Magic Machine")?;
+
     // Get an output port (read from console if multiple are available)
     let out_port = match midi_out.port_count() {
         0 => return Err("no output port found".into()),
         1 => {
-            println!("Choosing the only available output port: {}", midi_out.port_name(0).unwrap());
+            println!(
+                "Choosing the only available output port: {}",
+                midi_out.port_name(0).unwrap()
+            );
             0
-        },
+        }
         _ => {
             println!("\nAvailable output ports:");
             for i in 0..midi_out.port_count() {
@@ -36,7 +180,7 @@ fn run() -> Result<(), Box<Error>> {
             input.trim().parse()?
         }
     };
-    
+
     println!("\nOpening connection");
     let mut conn_out = midi_out.connect(out_port, "midir-test")?;
     println!("Connection open. Listen!");
@@ -48,15 +192,26 @@ fn run() -> Result<(), Box<Error>> {
             const VELOCITY: u8 = 0x64;
             // We're ignoring errors in here
             let _ = conn_out.send(&[NOTE_ON_MSG, note, VELOCITY]);
-            sleep(Duration::from_millis(duration * 150));
+            sleep(Duration::from_millis(duration * 100));
             let _ = conn_out.send(&[NOTE_OFF_MSG, note, VELOCITY]);
         };
-        
-        for i in 0..66 {
-            play_note(i, 2);
+
+        // play some notes
+        loop {
+            for i in 36..76 {
+                play_note(i, 4);
+
+                play_note(i + 7, 4);
+            }
+
+            for i in 76..36 {
+                play_note(i, 4);
+
+                play_note(i + 7, 4);
+            }
         }
     }
-    sleep(Duration::from_millis(150));
+
     println!("\nClosing connection");
     // This is optional, the connection would automatically be closed as soon as it goes out of scope
     conn_out.close();

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,10 +55,6 @@ fn main() {
 
     let notes = notes_in_channel(timed_midi_messages);
 
-    /*for n in notes.iter().take(10) {
-        println!("\tvtime hex {:04X} ... {:?}", n.vtime, n);
-    }*/
-
     match run(notes) {
         Ok(_) => (),
         Err(err) => println!("Error: {}", err.description()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,21 +50,14 @@ fn main() {
     }[..];
 
     let track_events = load_midi_file(pathstr);
-    println!("We have {} track events", track_events.len());
 
     let timed_midi_messages = midi_messages_from(track_events);
-    println!("We have {} timed midi messages", timed_midi_messages.len());
-
-    for i in 0..20 {
-        println!("\t{:?}", timed_midi_messages[i])
-    }
 
     let notes = notes_in_channel(timed_midi_messages);
 
-    println!("We have {} PlayNote instructions", notes.len());
-    for n in notes.iter() {
+    /*for n in notes.iter().take(10) {
         println!("\tvtime hex {:04X} ... {:?}", n.vtime, n);
-    }
+    }*/
 
     match run(notes) {
         Ok(_) => (),
@@ -187,17 +180,13 @@ fn run(notes: Vec<MidiNote>) -> Result<(), Box<Error>> {
     {
         // Define a new scope in which the closure `play_note` borrows conn_out, so it can be called easily
         let mut play_note = |midi: MidiNote| {
-            const NOTE_ON_MSG: u8 = 0x90;
-            const NOTE_OFF_MSG: u8 = 0x80;
             // We're ignoring errors in here
-            sleep(Duration::from_millis(midi.vtime * 10));
+            sleep(Duration::from_millis(midi.vtime * 2));
 
             let _ = match midi.channel_note {
-                 ChannelNote::On(c) =>  conn_out.send(&[c, midi.note, midi.velocity]),
-                 ChannelNote::Off(c) => conn_out.send(&[c, midi.note, midi.velocity]),
+                ChannelNote::On(c) => conn_out.send(&[c, midi.note, midi.velocity]),
+                ChannelNote::Off(c) => conn_out.send(&[c, midi.note, midi.velocity]),
             };
-            
-            
         };
 
         for n in notes {


### PR DESCRIPTION
Uses `rtmidi`, `rimd` and `midir` libs to read MIDI from Bach Goldberg Variations and play it.  Tested on Mac OS X using `SimpleSynth`.